### PR TITLE
change for client-server error opsc-16778

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject http-kit "2.3.0"
+(defproject  http-kit-non-standard "2.3.0"
   :author "Feng Shen (@shenfeng)"
   :description "High-performance event-driven HTTP client/server for Clojure"
   :url "http://http-kit.org/"

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -36,8 +36,9 @@ public class HttpClient implements Runnable {
 
     static {
         try {
-            DEFAULT_CONTEXT = SSLContext.getDefault();
-        } catch (NoSuchAlgorithmException e) {
+            DEFAULT_CONTEXT = SSLContext.getInstance("TLS");
+            DEFAULT_CONTEXT.init(null, TrustManagerFactory.getTrustManagers() ,null);
+        } catch (Exception e) {
             throw new Error("Failed to initialize SSLContext", e);
         }
     }
@@ -70,8 +71,8 @@ public class HttpClient implements Runnable {
     }
 
     public static interface SSLEngineURIConfigurer {
-        public static final SSLEngineURIConfigurer NOP = new SSLEngineURIConfigurer() {
-            public void configure(SSLEngine sslEngine, URI uri) { /* do nothing */ }
+        public static final SSLEngineURIConfigurer CLIENT_MODE = new SSLEngineURIConfigurer() {
+            public void configure(SSLEngine sslEngine, URI uri) { sslEngine.setUseClientMode(true); }
         };
         void configure(SSLEngine sslEngine, URI uri);
     }
@@ -105,7 +106,7 @@ public class HttpClient implements Runnable {
     }
 
     public HttpClient(long maxConnections) throws IOException {
-        this(maxConnections, AddressFinder.DEFAULT, SSLEngineURIConfigurer.NOP,
+        this(maxConnections, AddressFinder.DEFAULT, SSLEngineURIConfigurer.CLIENT_MODE,
                 ContextLogger.ERROR_PRINTER, EventLogger.NOP, EventNames.DEFAULT);
     }
 

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -119,7 +119,7 @@
     (if ssl-configurer
       (reify HttpClient$SSLEngineURIConfigurer
         (configure [this ssl-engine uri] (ssl-configurer ssl-engine uri)))
-      HttpClient$SSLEngineURIConfigurer/NOP)
+      HttpClient$SSLEngineURIConfigurer/CLIENT_MODE)
     (if error-logger
       (reify ContextLogger
         (log [this message error] (error-logger message error)))

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -23,7 +23,7 @@
     :max-ws             ; Max websocket message size
     :max-line           ; Max http inital line length
     :proxy-protocol     ; Proxy protocol e/o #{:disable :enable :optional}
-    :worker-name-prefix ; Woker thread name prefix
+    :worker-name-prefix ; Worker thread name prefix
     :worker-pool        ; ExecutorService to use for request-handling (:thread,
                           :worker-name-prefix, :queue-size are ignored if set)
     :error-logger       ; Arity-2 fn (args: string text, exception) to log errors


### PR DESCRIPTION
change for opsc-16778 Client/Server mode has not yet been set error from agent with use_ssl enabled and java 270+.

This code change is performed over http-kit 2.3.0.

location in datastax: datastax-public-releases-local/com/datastax/opscenter/http-kit-non-standard/2.3.0/http-kit-non-standard-2.3.0.jar